### PR TITLE
Render effective Navigation submenu settings without persisting repairs

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -22,6 +22,7 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	useBlockEditingMode,
 	BlockControls,
+	BlockContextProvider,
 } from '@wordpress/block-editor';
 import {
 	EntityProvider,
@@ -362,28 +363,14 @@ function Navigation( {
 		innerBlocks,
 	} = useInnerBlocks( clientId );
 
-	// Reset submenuVisibility to default if orientation changes to horizontal
-	// while "always" is selected, but only when the Navigation block or one
-	// of its inner blocks is being edited. Rendering related template parts
-	// should not mark them dirty.
-	useEffect( () => {
-		if (
-			( isSelected || isInnerBlockSelected ) &&
-			orientation === 'horizontal' &&
-			submenuVisibility === 'always'
-		) {
-			setAttributes( {
-				submenuVisibility: 'hover',
-				showSubmenuIcon: true,
-			} );
-		}
-	}, [
-		isSelected,
-		isInnerBlockSelected,
+	const {
+		submenuVisibility: effectiveSubmenuVisibility,
+		showSubmenuIcon: effectiveShowSubmenuIcon,
+	} = getEffectiveSubmenuSettings( {
 		orientation,
 		submenuVisibility,
-		setAttributes,
-	] );
+		showSubmenuIcon,
+	} );
 
 	// Use a ref to store whether we've confirmed a page-list has submenus.
 	// Once confirmed, we don't need to keep checking the page-list blocks.
@@ -766,9 +753,9 @@ function Navigation( {
 	);
 
 	const submenuAccessibilityNotice =
-		! showSubmenuIcon &&
-		submenuVisibility !== 'click' &&
-		submenuVisibility !== 'always'
+		! effectiveShowSubmenuIcon &&
+		effectiveSubmenuVisibility !== 'click' &&
+		effectiveSubmenuVisibility !== 'always'
 			? __(
 					'The current menu options offer reduced accessibility for users and are not recommended. Enabling either "Open on Click" or "Show arrow" offers enhanced accessibility by allowing keyboard users to browse submenus selectively.'
 			  )
@@ -813,7 +800,7 @@ function Navigation( {
 								</h3>
 								<ToolsPanelItem
 									hasValue={ () =>
-										submenuVisibility !== 'hover'
+										effectiveSubmenuVisibility !== 'hover'
 									}
 									label={ __( 'Submenu Visibility' ) }
 									onDeselect={ () =>
@@ -826,7 +813,7 @@ function Navigation( {
 									<ToggleGroupControl
 										__next40pxDefaultSize
 										label={ __( 'Submenu Visibility' ) }
-										value={ submenuVisibility }
+										value={ effectiveSubmenuVisibility }
 										onChange={ ( value ) => {
 											const newAttributes = {
 												submenuVisibility: value,
@@ -867,7 +854,9 @@ function Navigation( {
 								</ToolsPanelItem>
 
 								<ToolsPanelItem
-									hasValue={ () => ! showSubmenuIcon }
+									hasValue={ () =>
+										! effectiveShowSubmenuIcon
+									}
 									label={ __( 'Show arrow' ) }
 									onDeselect={ () =>
 										setAttributes( {
@@ -875,21 +864,24 @@ function Navigation( {
 										} )
 									}
 									isDisabled={
-										submenuVisibility === 'click' ||
-										submenuVisibility === 'always'
+										effectiveSubmenuVisibility ===
+											'click' ||
+										effectiveSubmenuVisibility === 'always'
 									}
 									isShownByDefault
 								>
 									<ToggleControl
-										checked={ showSubmenuIcon }
+										checked={ effectiveShowSubmenuIcon }
 										onChange={ ( value ) => {
 											setAttributes( {
 												showSubmenuIcon: value,
 											} );
 										} }
 										disabled={
-											submenuVisibility === 'click' ||
-											submenuVisibility === 'always'
+											effectiveSubmenuVisibility ===
+												'click' ||
+											effectiveSubmenuVisibility ===
+												'always'
 										}
 										label={ __( 'Show arrow' ) }
 									/>
@@ -998,11 +990,20 @@ function Navigation( {
 						overlay={ overlay }
 						onNavigateToEntityRecord={ onNavigateToEntityRecord }
 					>
-						<UnsavedInnerBlocks
-							createNavigationMenu={ createNavigationMenu }
-							blocks={ uncontrolledInnerBlocks }
-							hasSelection={ isSelected || isInnerBlockSelected }
-						/>
+						<BlockContextProvider
+							value={ {
+								submenuVisibility: effectiveSubmenuVisibility,
+								showSubmenuIcon: effectiveShowSubmenuIcon,
+							} }
+						>
+							<UnsavedInnerBlocks
+								createNavigationMenu={ createNavigationMenu }
+								blocks={ uncontrolledInnerBlocks }
+								hasSelection={
+									isSelected || isInnerBlockSelected
+								}
+							/>
+						</BlockContextProvider>
 					</ResponsiveWrapper>
 				</TagName>
 			</>
@@ -1167,16 +1168,25 @@ function Navigation( {
 										onNavigateToEntityRecord
 									}
 								>
-									{ isEntityAvailable && (
-										<NavigationInnerBlocks
-											clientId={ clientId }
-											hasCustomPlaceholder={
-												!! CustomPlaceholder
-											}
-											templateLock={ templateLock }
-											orientation={ orientation }
-										/>
-									) }
+									<BlockContextProvider
+										value={ {
+											submenuVisibility:
+												effectiveSubmenuVisibility,
+											showSubmenuIcon:
+												effectiveShowSubmenuIcon,
+										} }
+									>
+										{ isEntityAvailable && (
+											<NavigationInnerBlocks
+												clientId={ clientId }
+												hasCustomPlaceholder={
+													!! CustomPlaceholder
+												}
+												templateLock={ templateLock }
+												orientation={ orientation }
+											/>
+										) }
+									</BlockContextProvider>
 								</ResponsiveWrapper>
 							</>
 						) }
@@ -1193,3 +1203,30 @@ export default withColors(
 	{ overlayBackgroundColor: 'color' },
 	{ overlayTextColor: 'color' }
 )( Navigation );
+
+function getEffectiveSubmenuSettings( {
+	orientation,
+	submenuVisibility,
+	showSubmenuIcon,
+} ) {
+	const resolvedSubmenuVisibility = submenuVisibility ?? 'hover';
+	const resolvedShowSubmenuIcon = showSubmenuIcon ?? true;
+
+	// Horizontal navigation menus cannot display always-open submenus. Treat
+	// older content with that combination as the horizontal default without
+	// writing the repaired values back to the entity.
+	if (
+		orientation === 'horizontal' &&
+		resolvedSubmenuVisibility === 'always'
+	) {
+		return {
+			submenuVisibility: 'hover',
+			showSubmenuIcon: true,
+		};
+	}
+
+	return {
+		submenuVisibility: resolvedSubmenuVisibility,
+		showSubmenuIcon: resolvedShowSubmenuIcon,
+	};
+}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -41,6 +41,28 @@ function block_core_navigation_get_submenu_visibility( $attributes ) {
 }
 
 /**
+ * Returns navigation attributes with impossible submenu settings coerced for rendering.
+ *
+ * Horizontal navigation menus cannot display always-open submenus. Older content may
+ * still contain that combination, so render it as the horizontal default without
+ * writing the repaired values back to the entity.
+ *
+ * @param array $attributes Block attributes.
+ * @return array Attributes to use for render behavior and block context.
+ */
+function block_core_navigation_get_effective_submenu_attributes( $attributes ) {
+	$orientation        = $attributes['layout']['orientation'] ?? 'horizontal';
+	$submenu_visibility = block_core_navigation_get_submenu_visibility( $attributes );
+
+	if ( 'horizontal' === $orientation && 'always' === $submenu_visibility ) {
+		$attributes['submenuVisibility'] = 'hover';
+		$attributes['showSubmenuIcon']   = true;
+	}
+
+	return $attributes;
+}
+
+/**
  * Helper functions used to render the navigation block.
  *
  * @since 6.5.0
@@ -474,10 +496,22 @@ class WP_Navigation_Block_Renderer {
 	 *
 	 * @param array    $attributes The block attributes.
 	 * @param WP_Block $block The parsed block.
+	 * @param bool     $use_effective_context Whether to rebuild inline inner blocks with effective block context.
 	 * @return WP_Block_List Returns the inner blocks for the navigation block.
 	 */
-	private static function get_inner_blocks( $attributes, $block ) {
-		$inner_blocks = $block->inner_blocks;
+	private static function get_inner_blocks(
+		$attributes,
+		$block,
+		$use_effective_context = false
+	) {
+		$use_parsed_inner_blocks = $use_effective_context &&
+			! empty( $block->parsed_block['innerBlocks'] );
+		$inner_blocks            = $use_parsed_inner_blocks
+			? new WP_Block_List(
+				$block->parsed_block['innerBlocks'],
+				$attributes
+			)
+			: $block->inner_blocks;
 
 		// Ensure that blocks saved with the legacy ref attribute name (navigationMenuId) continue to render.
 		if ( array_key_exists( 'navigationMenuId', $attributes ) ) {
@@ -991,7 +1025,11 @@ class WP_Navigation_Block_Renderer {
 
 		unset( $attributes['rgbTextColor'], $attributes['rgbBackgroundColor'] );
 
-		$inner_blocks = static::get_inner_blocks( $attributes, $block );
+		$effective_attributes  = block_core_navigation_get_effective_submenu_attributes( $attributes );
+		$use_effective_context = $effective_attributes !== $attributes;
+		$attributes            = $effective_attributes;
+
+		$inner_blocks = static::get_inner_blocks( $attributes, $block, $use_effective_context );
 		// Prevent navigation blocks referencing themselves from rendering.
 		if ( block_core_navigation_block_tree_has_block_type(
 			$inner_blocks,

--- a/test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js
@@ -82,7 +82,7 @@ test.describe( 'Navigation passive rendering', () => {
 		await requestUtils.createTemplate( 'wp_template_part', {
 			slug: 'header',
 			title: 'Header',
-			content: `<!-- wp:navigation {"ref":${ menu.id },"overlayMenu":"off","submenuVisibility":"always"} /-->`,
+			content: `<!-- wp:navigation {"ref":${ menu.id },"overlayMenu":"never","submenuVisibility":"always"} /-->`,
 		} );
 
 		await requestUtils.createTemplate( 'wp_template', {
@@ -115,6 +115,11 @@ test.describe( 'Navigation passive rendering', () => {
 			} )
 		).toBeVisible();
 
+		await expect.poll( () => getDirtyEntityRecords( page ) ).toEqual( [] );
+
+		await editor.canvas
+			.getByRole( 'document', { name: 'Block: Navigation' } )
+			.click();
 		await expect.poll( () => getDirtyEntityRecords( page ) ).toEqual( [] );
 
 		await editor.canvas


### PR DESCRIPTION
## What

This is a draft follow-up to WordPress/gutenberg#79000 that explores the render-time/effective-value approach suggested in review.

Instead of repairing the stale horizontal Navigation `submenuVisibility: "always"` state with `setAttributes`, this branch treats that impossible combination as the horizontal default while rendering/editor UI runs:

- effective `submenuVisibility`: `hover`
- effective `showSubmenuIcon`: `true`

The stored block attributes are left untouched unless the user makes an explicit attribute change.

## Why

PR #79000 prevents passive rendering from dirtying related entities, but selecting the stale Navigation block can still dirty the template part because the repair effect still writes attributes. This draft removes that effect and applies the effective values to editor rendering/context instead.

The PHP render path also coerces the same impossible combination before rendering, so pre-existing stored invalid attributes do not render differently between editor and frontend.

## Notes / risks to review

- This intentionally changes how pre-existing horizontal Navigation blocks with `submenuVisibility: "always"` are interpreted at render time.
- Inline Navigation inner blocks are rebuilt with effective context only when the effective attributes differ from stored attributes; this is to keep child block context consistent without changing the common path.
- This does not make impossible states unrepresentable. A deeper data-model/UI change would still be needed for that.

## Testing

- `php -l packages/block-library/src/navigation/index.php`
- `node --check test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js`
- `git diff --check`
- `wp-scripts format --check packages/block-library/src/navigation/edit/index.js test/e2e/specs/editor/blocks/navigation-passive-rendering.spec.js`

Local wp-env/E2E is still blocked in this workspace because Docker/OrbStack is not running.
